### PR TITLE
v2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See the full settings page [here](/screenshots/wp_settings.png "")
 
 It's also recommended to rename the class file names to adhere to WordPress <a href="http://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions">naming conventions</a>.
 
-See the example below and the [example plugin](/example-plugin.php "") on how to implement the settings classes.
+See the example below [simple example plugin](/example-plugin-simple.php "") and the [example plugin](/example-plugin.php "") on how to implement the settings classes.
 
 ### Example
 
@@ -389,36 +389,40 @@ Here's an example of how you can manually add admin pages without the `add_page(
 $pages = array(
 
 	/* Admin page array */
-	array(
-		'id'    => 'example_page', // required
-		'slug'  => 'example',      // required
-		'title' => __( 'Page one', 'plugin-text-domain' ),
-		'sections' => array(       // required. Array of page sections.
-
-			/* Section Array */
+		$pages = array(
+		
+			/* Admin page array */
 			array(
-				'id'     => 'section_one_settings', // required (database option name)
-				'title'  => __( 'Section One', 'plugin-text-domain' ),
-				'fields' => array(
-
-					/* Field Array */
+				'id'    => 'example_page_simple', // required
+				'slug'  => 'example_simple',      // required
+				'title' => __( 'Page one', 'plugin-text-domain' ),
+				'sections' => array(       // required. Array of page sections.
+		
+					/* Section Array */
 					array(
-						'id'    => 'text_input', // required
-						'type'  => 'text',       // required
-						'label' => 'Name',
-						'desc'  => 'Your Name',
+						'id'     => 'settings_section_one', // required (database option name)
+						'title'  => __( 'Section One', 'plugin-text-domain' ),
+						'fields' => array(
+		
+							/* Field Array */
+							array(
+								'id'    => 'text_input', // required
+								'type'  => 'text',       // required
+								'label' => 'Name',
+								'desc'  => 'Your Name',
+								'default' => 'John Doe'
+							),
+		
+							// Add more field arrays here.
+						),
 					),
-
-					// Add more field arrays here.
+		
+					// Add more section arrays here.
 				),
 			),
-
-			// Add more section arrays here.
-		),
-	),
-
-	// Add more admin page arrays here.
-);
+		
+			// Add more admin page arrays here.
+		);
 
 // Instantiate the settings class.
 $settings = new WP_Settings_Settings();

--- a/example-plugin-simple.php
+++ b/example-plugin-simple.php
@@ -1,0 +1,163 @@
+<?php
+/*
+ * Plugin Name: 		WP Settings Simple Example Plugin
+ * Description: 		Commented plugin example of adding one admin page with WP Settings.
+ * Plugin URI:  		https://github.com/keesiemeijer/WP-Settings
+ * Version:           	2.1
+ * Author:            	keesiemeijer
+ * Author URI:  		https://github.com/keesiemeijer
+ * License:     		GPL-2.0+
+ * License URI:       	https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       	plugin-text-domain
+ *
+ * @package           	WP_Settings
+ */
+
+if ( is_admin() ) {
+
+	// Include the Settings classes.
+	require_once plugin_dir_path( __FILE__ ) . 'wp-settings-fields.php';
+	require_once plugin_dir_path( __FILE__ ) . 'wp-settings.php';
+
+}
+
+// Example plugin class.
+class WP_Settings_Example_Simple {
+
+	private $page_hook;
+	private $settings;
+
+	function __construct() {
+	
+		// Set the page_hook to the base options table prefix that we want to use
+		$this->page_hook = 'example_plugin_simple';
+		
+		// Adds the plugin admin menu.
+		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+
+		// Initialize the settings class on admin_init.
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
+	}
+
+
+	function admin_menu() {
+		// Create the admin settings page in wp-admin > Settings (options-general.php).
+		// Use the page_hook as the options table prefix
+		add_submenu_page( 
+			'options-general.php', 
+			__( 'Simple Example Admin Page', 'plugin-text-domain' ),  
+			__( 'Simple Example Admin Page', 'plugin-text-domain' ), 
+			'administrator', 
+			$this->page_hook, 
+			array( $this, 'admin_page' ) 
+		);
+	}
+
+
+	function admin_init() {
+
+		// Instantiate the settings class.
+		$this->settings = new WP_Settings_Settings();
+
+		// Create a single $pages array with the page, section, and fields
+		$pages = array(
+		
+			/* Admin page array */
+			array(
+				'id'    => 'example_page_simple', // required
+				'slug'  => 'example_simple',      // required
+				'title' => __( 'Page one', 'plugin-text-domain' ),
+				'sections' => array(       // required. Array of page sections.
+		
+					/* Section Array */
+					array(
+						'id'     => 'settings_section_one', // required (database option name)
+						'title'  => __( 'Section One', 'plugin-text-domain' ),
+						'fields' => array(
+		
+							/* Field Array */
+							array(
+								'id'    => 'text_input', // required
+								'type'  => 'text',       // required
+								'label' => 'Name',
+								'desc'  => 'Your Name',
+								'default' => 'John Doe'
+							),
+		
+							// Add more field arrays here.
+						),
+					),
+		
+					// Add more section arrays here.
+				),
+			),
+		
+			// Add more admin page arrays here.
+		);
+
+		// Almost done.
+		// Initialize the settings with the $pages array and the unique page hook.
+		$this->settings->init( $pages, $this->page_hook );
+
+		// That's it.
+
+	} // admin_init
+
+
+	function admin_page() {
+		// Display the example plugin admin page.
+		echo '<div class="wrap">';
+
+		// Display settings errors if it's not a settings page (options-general.php).
+		// settings_errors();
+
+		// Display the plugin title and tabbed navigation.
+		$this->settings->render_header( __( 'WP Settings Simple Example', 'plugin-text-domain' ) );
+
+		// Display debug messages (only needed when developing).
+		// Displays errors and the database options created for this page.
+		// echo $this->settings->debug;
+
+		// Use the function get_settings() to get all the settings.
+		// $settings = $this->settings->get_settings();
+
+		// Use the function get get_current_admin_page() to check what page you're on
+		// $page         = $this->settings->get_current_admin_page();
+		// $current_page = $page['id'];
+
+		// Display the form(s).
+		$this->settings->render_form();
+		echo '</div>';
+	}
+
+
+	function validate_section( $fields ) {
+
+		// Validation of the section_one_text text input.
+		// Show an error if it's empty.
+
+		// to check the section that's being validated you can check the 'section_id'
+		// that was added with a hidden field in the admin page form.
+		//
+		// example
+		// if( 'first_section' === $fields['section_id'] ) { // do stuff }
+
+		if ( empty( $fields['section_one_text'] ) ) {
+
+			// Use add_settings_error() to show an error messages.
+			add_settings_error(
+				'section_one_text', // Form field id.
+				'texterror', // Error id.
+				__( 'Error: please enter some text.', 'plugin-text-domain' ), // Error message.
+				'error' // Type of message. Use 'error' or 'updated'.
+			);
+		}
+
+		// Don't forget to return the fields
+		return $fields;
+	}
+
+} // end of class
+
+// Instantiate your plugin class.
+$settings = new WP_Settings_Example_Simple();

--- a/example-plugin.php
+++ b/example-plugin.php
@@ -1,8 +1,17 @@
 <?php
 /*
-* Plugin Name: WP Settings Example Plugin
-* Description: Commented plugin example of adding two admin pages with WP Settings.
-*/
+ * Plugin Name: WP Settings Example Plugin
+ * Description: Commented plugin example of adding two admin pages with WP Settings.
+ * Plugin URI:  		https://github.com/keesiemeijer/WP-Settings
+ * Version:           	2.1
+ * Author:            	keesiemeijer
+ * Author URI:  		https://github.com/keesiemeijer
+ * License:     		GPL-2.0+
+ * License URI:       	https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       	plugin-text-domain
+ *
+ * @package           	WP_Settings
+ */
 
 if ( is_admin() ) {
 
@@ -201,7 +210,20 @@ class WP_Settings_Example {
 					'no'    => __( 'No', 'wp-settings' ),
 					'maybe' => __( 'Maybe', 'wp-settings' ),
 				)
-			),  // end of field
+			),
+			
+			/* number */
+			array(
+				'id'      => 'section_one_number', // required
+				'type'    => 'number', // required
+				'label'   => __( 'Number', 'wp-settings' ),
+				'size'    => 'small', // defaults to regular. Sizes 'regular' - 'large' - 'small'
+				'default' => 500,
+				'min'	  => 0,
+				'max'	  => 100,
+				'step'	  => 50,
+				'desc'    => __('Number field description. The range is 0 to 1000 in increments of 50.', 'wp-settings'),
+			),	// end of fields
 		);
 
 		// Add the fields for the first admin page to the first section.

--- a/wp-settings-fields.php
+++ b/wp-settings-fields.php
@@ -156,6 +156,38 @@ if ( !class_exists( 'WP_Settings_Settings_Fields' ) ) {
 			echo '</fieldset>' . $html . $this->description( $args['desc'] );
 		}
 
+		/**
+		 * Displays a number input setting field.
+		 *
+		 * @param array   $args
+		 * @param string  $type Type attribute
+		 */
+		public function callback_number( $args ) {
+			$args['size'] = ( isset( $args['size'] ) && $args['size'] ) ? $args['size'] : 'regular';
+			$type = !empty( $args['text_type'] ) ? esc_attr( $args['text_type'] ) : 'number';
+			$args  = $this->get_arguments( $args ); // escapes all attributes
+			$value = (int) esc_attr( $this->get_option( $args ) );
+			$error = $this->get_setting_error( $args['id'] );
+			$min = esc_attr( $args['min'] ) ?? 0;
+			$max = esc_attr( $args['max'] );
+			$step = esc_attr( $args['step'] );
+			$min_max_step = is_numeric ( $min ) ? ' min="' . $min . '"' : '';
+			$min_max_step .= $max ? ' max="' . $max . '"' : '';
+			$min_max_step .= $step ? ' step="' . $step . '"' : '';
+			
+			$html  = sprintf( 
+				'<input type="%6$s"%7$s id="%1$s_%2$s" name="%1$s[%2$s]" value="%3$s"%4$s%5$s/>',  
+				$args['section'], 
+				$args['id'], 
+				$value, 
+				$args['attr'], 
+				$error, 
+				$type,
+				$min_max_step
+			);
+
+			echo $args['before'] . $html . $args['after'] . $this->description( $args['desc'] );
+		}
 
 		/**
 		 * Displays type 'content' field.

--- a/wp-settings.php
+++ b/wp-settings.php
@@ -3,7 +3,7 @@
  * Class for registering settings and sections and for display of the settings form(s).
  * For detailed instructions see: https://github.com/keesiemeijer/WP-Settings
  *
- * @version 2.0
+ * @version 2.1
  *
  * @author keesiemeijer
  */
@@ -240,8 +240,8 @@ if ( !class_exists( 'WP_Settings_Settings' ) ) {
 
 					$args = wp_parse_args( $opt, $defaults );
 
-					$args['default'] = ( $use_defaults ) ? $args['default'] : '';
-					$opt_defaults[ $opt['id'] ] = $args['default'];
+					$opt_default = ( $use_defaults ) ? $args['default'] : ''; //ADD
+					$opt_defaults[ $opt['id'] ] = $opt_default; //ADD
 
 					if ( in_array( $args['type'], $this->script_types ) ) {
 						$this->load_scripts[] = $args['type']; // field needs javascript
@@ -544,7 +544,7 @@ if ( !class_exists( 'WP_Settings_Settings' ) ) {
 		public function render_header( $plugin_title = '', $tab_id = false ) {
 
 			if ( !empty( $plugin_title ) )
-				echo get_screen_icon() . '<h2>' . (string) $plugin_title . '</h2>';
+				echo '<h2>' . (string) $plugin_title . '</h2>';
 
 			// if ( !$this->valid_pages )
 			//  return;


### PR DESCRIPTION
* Enhanced the field defaulting logic so that new fields added after the initial settings are saved get their specified default value.
* Added support for number fields (type is 'number'), including optional min, max, and step.
* Added example-plugin-simple.php based on the simpler way of using a single $pages array rather than individual add_pages(), add_sections(), and add_fields() functions.
* Added additional plugin meta data to both plugin examples, such as plugin URI, author and author URI.
* Updated the README to reference the new simple plugin example.